### PR TITLE
Core changes

### DIFF
--- a/lib/rails_soft_deletable/version.rb
+++ b/lib/rails_soft_deletable/version.rb
@@ -1,3 +1,3 @@
 module RailsSoftDeletable
-  VERSION = "0.1.0"
+  VERSION = "0.2.0"
 end

--- a/spec/dummy/lib/soft_deletable_model_callbacks.rb
+++ b/spec/dummy/lib/soft_deletable_model_callbacks.rb
@@ -1,6 +1,8 @@
 module SoftDeletableModelCallbacks
   def self.included(base)
     base.class_eval do
+      attr_reader :callback_order
+
       attr_reader :before_destroy_called
       attr_reader :around_destroy_called
       attr_reader :after_destroy_called
@@ -8,6 +10,8 @@ module SoftDeletableModelCallbacks
       attr_reader :before_restore_called
       attr_reader :around_restore_called
       attr_reader :after_restore_called
+
+      attr_reader :after_commit_called
 
       before_destroy :call_before_destroy
       around_destroy :call_around_destroy
@@ -17,33 +21,41 @@ module SoftDeletableModelCallbacks
       around_restore :call_around_restore
       after_restore  :call_after_restore
 
+      after_commit :call_after_commit, on: :destroy
+
       def call_before_destroy
-        @before_destroy_called = true
+        @before_destroy_called = next_callback_order
       end
 
       def call_around_destroy
+        @around_destroy_called = next_callback_order
         yield
-        @around_destroy_called = true
       end
 
       def call_after_destroy
-        @after_destroy_called = true
+        @after_destroy_called = next_callback_order
       end
 
       def call_before_restore
-        @before_restore_called = true
+        @before_restore_called = next_callback_order
       end
 
       def call_around_restore
+        @around_restore_called = next_callback_order
         yield
-        @around_restore_called = true
       end
 
       def call_after_restore
-        @after_restore_called = true
+        @after_restore_called = next_callback_order
+      end
+
+      def call_after_commit
+        @after_commit_called = next_callback_order
       end
 
       def reset_callback_flags!
+        @callback_order = 0
+
         @before_destroy_called = nil
         @around_destroy_called = nil
         @after_destroy_called  = nil
@@ -51,6 +63,13 @@ module SoftDeletableModelCallbacks
         @before_restore_called = nil
         @around_restore_called = nil
         @after_restore_called  = nil
+
+        @after_commit_called = nil
+      end
+
+      def next_callback_order
+        @callback_order ||= 0
+        @callback_order += 1
       end
     end
   end

--- a/spec/rails_soft_deletable_spec.rb
+++ b/spec/rails_soft_deletable_spec.rb
@@ -240,9 +240,16 @@ describe RailsSoftDeletable do
     it "performs destroy callbacks" do
       model.destroy
 
-      expect(model.before_destroy_called).to eq(true)
-      expect(model.around_destroy_called).to eq(true)
-      expect(model.after_destroy_called).to eq(true)
+      expect(model.before_destroy_called).to eq(1)
+      expect(model.around_destroy_called).to eq(2)
+      expect(model.after_destroy_called).to eq(3)
+    end
+
+    it "performs commit callbacks" do
+      model.destroy
+
+      expect(model.after_commit_called).to eq(4)
+      expect(model.after_commit_called).to be > model.after_destroy_called
     end
 
     context "when record has already been soft deleted" do
@@ -251,19 +258,12 @@ describe RailsSoftDeletable do
         model.reset_callback_flags!
       end
 
-      it "does not perform destroy callbacks" do
+      it "continues to call destroy callbacks" do
         model.destroy
 
-        expect(model.before_destroy_called).to be_nil
-        expect(model.around_destroy_called).to be_nil
-        expect(model.after_destroy_called).to be_nil
-      end
-
-      it "hard deletes the record from the database" do
-        model.destroy
-
-        count = model.class.connection.select_value("SELECT COUNT(*) FROM #{model.class.quoted_table_name} WHERE #{model.class.primary_key} = #{model.id}")
-        expect(count).to eq(0)
+        expect(model.before_destroy_called).to eq(1)
+        expect(model.around_destroy_called).to eq(2)
+        expect(model.after_destroy_called).to eq(3)
       end
     end
 
@@ -278,9 +278,9 @@ describe RailsSoftDeletable do
       it "performs destroy callbacks" do
         model.destroy(:hard)
 
-        expect(model.before_destroy_called).to eq(true)
-        expect(model.around_destroy_called).to eq(true)
-        expect(model.after_destroy_called).to eq(true)
+        expect(model.before_destroy_called).to eq(1)
+        expect(model.around_destroy_called).to eq(2)
+        expect(model.after_destroy_called).to eq(3)
       end
     end
   end
@@ -356,13 +356,6 @@ describe RailsSoftDeletable do
         expect(model.around_destroy_called).to be_nil
         expect(model.after_destroy_called).to be_nil
       end
-
-      it "hard deletes the record from the database" do
-        model.delete
-
-        count = model.class.connection.select_value("SELECT COUNT(*) FROM #{model.class.quoted_table_name} WHERE #{model.class.primary_key} = #{model.id}")
-        expect(count).to eq(0)
-      end
     end
 
     context "with hard delete mode" do
@@ -410,9 +403,9 @@ describe RailsSoftDeletable do
     it "performs restore callbacks" do
       model.restore!
 
-      expect(model.before_restore_called).to eq(true)
-      expect(model.around_restore_called).to eq(true)
-      expect(model.after_restore_called).to eq(true)
+      expect(model.before_restore_called).to eq(1)
+      expect(model.around_restore_called).to eq(2)
+      expect(model.after_restore_called).to eq(3)
     end
 
     it "returns true" do


### PR DESCRIPTION
* Calling `#destroy` multiple times no longer hard deletes the row, use `#destroy(:hard)`
  instead. This makes things more explicit.
* Fix a bug where `after_commit` was being fired before `after_destroy`.